### PR TITLE
Fix uninitialized ProtocolError

### DIFF
--- a/lib/mc_protocol/frame1e/client.rb
+++ b/lib/mc_protocol/frame1e/client.rb
@@ -159,7 +159,7 @@ module McProtocol::Frame1e
       # 終了コード(エラーコード)
       if res[1] != 0x00
         if res[1] == 0x5b
-          raise ProtocolError.new res[2]
+          raise McProtocol::ProtocolError.new res[2]
         else
           raise "不明なエラー"
         end

--- a/lib/mc_protocol/frame3e/client.rb
+++ b/lib/mc_protocol/frame3e/client.rb
@@ -168,7 +168,7 @@ module McProtocol::Frame3e
 
       # 終了コード(エラーコード)
       end_code = res[9..10].reverse.pack("c*").unpack("H*").first.upcase
-      raise ProtocolError.new end_code if end_code != "0000"
+      raise McProtocol::ProtocolError.new end_code if end_code != "0000"
 
       # データ
       data = res[11..-1]


### PR DESCRIPTION
# About this PR
- `NameError: uninitialized constant McProtocol::Frame3e::Client:ProtocolError` の問題を対応しました。
<img width="1364" alt="image (8)" src="https://user-images.githubusercontent.com/31838397/168991982-ba7d4dbe-2272-46ac-8deb-7fd38c95a13e.png">


# Issue
close #35
